### PR TITLE
Fixed typo for the file to install in the 'Requirements' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ URL https://www.nature.com/articles/s41467-020-17419-7
 Use `python > 3.6` and install the requirements:
 
 ```
-pip install -r requiurements.txt
+pip install -r requirements.txt
 ```
 
 ## Running


### PR DESCRIPTION
The file to install was misspelled, it contained an extra 'u'.